### PR TITLE
Added ability to set global sanitizers.

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -61,11 +61,38 @@ class Sanitizer
      */
     public function sanitize($rules, &$data)
     {
+        // Process global sanitizers.
+        $this->runGlobalSanitizers($rules, $data);
+
         // Iterate rules to be applied.
         foreach ($rules as $field => $ruleset) {
 
             // Execute sanitizers over a specific field.
             $this->sanitizeField($data, $field, $ruleset);
+        }
+    }
+
+    /**
+     * Apply global sanitizer rules.
+     *
+     * @param  array $rules
+     * @param  array $data
+     * @return void
+     */
+    protected function runGlobalSanitizers(&$rules, &$data)
+    {
+        // Bail out if no global rules were found.
+        if (!isset($rules['*'])) {
+            return;
+        }
+
+        // Get the global rules and remove them from the main ruleset.
+        $global_rules = $rules['*'];
+        unset($rules['*']);
+
+        // Execute the global sanitiers on each field.
+        foreach ($data as $field => $value) {
+            $this->sanitizeField($data, $field, $global_rules);
         }
     }
 

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -54,6 +54,23 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         $s->sanitize(['name' => 'strrev|alphabetize|trim'], $d);
         $this->assertEquals('elyaD', $d['name']);
     }
+
+    public function testThatGlobalRulesCanBeSet()
+    {
+        $s = new Sanitizer;
+        $d = [
+            'first_name' => ' Dayle',
+            'last_name' => 'Rees ',
+        ];
+        $s->sanitize([
+            '*' => 'trim|strtolower',
+            'last_name' => 'strrev',
+        ], $d);
+        $this->assertEquals([
+            'first_name' => 'dayle',
+            'last_name' => 'seer',
+        ], $d);
+    }
 }
 
 class TestSanitizer


### PR DESCRIPTION
I've added a feature that allows a user to set global sanitizer rules to be applied to every item in the dataset. Simply set an item in the rules array that uses `*` as the key, for example:

``` php
$rules = [
    '*' => 'trim|strtolower',
    'last_name' => 'strrev',
];
```

Global rules will then be processed prior to the field-specific rules. Does this sound useful to you?
