### PR TITLE
Fix for data which isnt posted in the sainitizer

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -67,7 +67,7 @@ class Sanitizer
         $availableRules = array_only($rules, array_keys($data));
 				
         // Iterate rules to be applied.
-        foreach ($rules as $field => $ruleset) {
+        foreach ($availableRules as $field => $ruleset) {
 
             // Execute sanitizers over a specific field.
             $this->sanitizeField($data, $field, $ruleset);


### PR DESCRIPTION
If a data field is missing the rule will set the value to be blank .

This PR fixes that.
