### PR TITLE
Update Sanitizer.php

### DIFF
--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -127,7 +127,6 @@ class Sanitizer
                 $parametersSet = explode(',', $parameters);
             }
             array_unshift($parametersSet, $value);
-            $value = $parametersSet;
 
             // Get the sanitizer.
             if (!$sanitizer = $this->getSanitizer($rule)) {
@@ -135,7 +134,7 @@ class Sanitizer
             }
 
             // Execute the sanitizer to mutate the value.
-            $value = $this->executeSanitizer($sanitizer, $value);
+            $value = $this->executeSanitizer($sanitizer, $parametersSet);
         }
 
         // Set the sanitized value in the data array


### PR DESCRIPTION
Fix issue where values without assigned sanitizer(s) would be returned back as an array by putting the value and parameters in $parameterSet, and making sure that $value only ever contains the original value or the returned, sanitized value.