### PR TITLE
Compatible with PHP 5.3

### DIFF
--- a/src/SanitizerServiceProvider.php
+++ b/src/SanitizerServiceProvider.php
@@ -14,7 +14,7 @@ class SanitizerServiceProvider extends ServiceProvider
     public function register()
     {
         $this->app['sanitizer'] = $this->app->share(function ($app) {
-            return new Sanitizer($this->app);
+            return new Sanitizer($app);
         });
     }
 }


### PR DESCRIPTION
Just a quick fix to the `SanitizerServiceProvider.php` file to use `$app` of `$this->app` inside a closure and be compatible with PHP 5.3.

``` php
    public function register()
    {
        $this->app['sanitizer'] = $this->app->share(function ($app) {
            return new Sanitizer($app);
        });
    }
```
