### PR TITLE
Add the ability to sanitize a single value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Thumbs.db
 .vagrant
 vendor
 composer.lock
+/.idea

--- a/readme.md
+++ b/readme.md
@@ -59,13 +59,13 @@ Using the Laravel facade, the syntax can be made a little cleaner.
 Sanitize a single value like so. 
 
     $rules = 'trim|strtolower';
-    $data = '  TONY Stark';
+    $data = '  Dayle';
     
     Sanitizer::sanitizeValue($rules, $data);
 
 Here is the value returned.
 
-    tony stark
+    dayle
 
 ## Custom Sanitization Rules
 

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,17 @@ Here's the content of `$data` after execution.
 Using the Laravel facade, the syntax can be made a little cleaner.
 
     Sanitizer::sanitize($rules, $data);
+    
+Sanitize a single value like so. 
+
+    $rules = 'trim|strtolower';
+    $data = '  TONY Stark';
+    
+    Sanitizer::sanitizeValue($rules, $data);
+
+Here is the value returned.
+
+    tony stark
 
 ## Custom Sanitization Rules
 

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -76,6 +76,24 @@ class Sanitizer
     }
 
     /**
+     * Sanitize a value using rules.
+     *
+     * @param string $rules
+     * @param string $value
+     *
+     * @return string
+     */
+    public function sanitizeValue($rules, $value)
+    {
+        $rules = ['value' => $rules];
+        $data = ['value' => $value];
+
+        $data = $this->sanitize($rules, $data);
+
+        return $data['value'];
+    }
+
+    /**
      * Apply global sanitizer rules.
      *
      * @param  array $rules

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -136,6 +136,15 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         ], $d);
     }
 
+    public function testItSanitizesASingleValue()
+    {
+        $s = new Sanitizer;
+
+        $value = $s->sanitizeValue('trim|strtolower', '   TONY sTArK    ');
+
+        $this->assertEquals('tony stark', $value);
+    }
+
 }
 
 class TestSanitizer

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -140,9 +140,9 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
     {
         $s = new Sanitizer;
 
-        $value = $s->sanitizeValue('trim|strtolower', '   TONY sTArK    ');
+        $value = $s->sanitizeValue('trim|strtolower', '   Dayle    ');
 
-        $this->assertEquals('tony stark', $value);
+        $this->assertEquals('dayle', $value);
     }
 
 }


### PR DESCRIPTION
``` php
$rules = 'trim|strtolower';
$data = '  Dayle';

Sanitizer::sanitizeValue($rules, $data);
```

```
dayle
```
