### PR TITLE
add support for closures in rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Rees\Sanitizer\SanitizerServiceProvider"
+                "Rees\\Sanitizer\\SanitizerServiceProvider"
             ],
-            "aliases": [
-                "Sanitizer": "Rees\Sanitizer\Facade"
-            ]
+            "aliases": {
+                "Sanitizer": "Rees\\Sanitizer\\Facade"
+            }
         }
     },
 }

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,5 @@
                 "Sanitizer": "Rees\\Sanitizer\\Facade"
             }
         }
-    },
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,15 @@
             "Rees\\Sanitizer\\": "src"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Rees\Sanitizer\SanitizerServiceProvider"
+            ],
+            "aliases": [
+                "Sanitizer": "Rees\Sanitizer\Facade"
+            ]
+        }
+    },
 }

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ First construct a rules array.
         'email'     => 'trim|strtolower'
     ];
 
-Rules can contain either callable functions, or the name of a sanitizer binding (more later). You can use either a pipe `|` or an array to specify multiple sanitization rules.
+Rules can contain either callable functions, closures, or the name of a sanitizer binding (more later). You can use either a pipe `|` or an array to specify multiple sanitization rules.
 
 The sanitizer can be executed in the following fashion.
 
@@ -29,7 +29,12 @@ Here's a full example.
 
     // Construct rules array.
     $rules = [
-        'name'      => 'trim',
+        'name'      => [
+            'trim',
+            function ($value) {
+                return strtoupper($value);
+            }
+        ],
         'email'     => 'trim|strtolower'
     ];
 
@@ -48,19 +53,19 @@ Here's a full example.
 Here's the content of `$data` after execution.
 
     [
-        'name' => 'Dayle',
+        'name' => 'DAYLE',
         'email' => 'me@daylerees.com'
     ]
 
 Using the Laravel facade, the syntax can be made a little cleaner.
 
     Sanitizer::sanitize($rules, $data);
-    
-Sanitize a single value like so. 
+
+Sanitize a single value like so.
 
     $rules = 'trim|strtolower';
     $data = '  Dayle';
-    
+
     Sanitizer::sanitizeValue($rules, $data);
 
 Here is the value returned.

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -140,15 +140,18 @@ class Sanitizer
 
             // If exists, getting parameters
             $parametersSet = array();
-            if (str_contains($rule, ':')) {
+            $isCallable = is_callable($rule);
+            if (!$isCallable && str_contains($rule, ':')) {
                 list($rule, $parameters) = explode(':', $rule);
                 $parametersSet = explode(',', $parameters);
             }
             array_unshift($parametersSet, $value);
 
             // Get the sanitizer.
-            if (!$sanitizer = $this->getSanitizer($rule)) {
+            if (!$isCallable && !$sanitizer = $this->getSanitizer($rule)) {
                 continue;
+            } elseif ($isCallable) {
+                $sanitizer = $rule;
             }
 
             // Execute the sanitizer to mutate the value.

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -63,6 +63,20 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Dayle Rees', $d['name']);
     }
 
+    public function testThatSanitizerCanSanitizeWithRealClosure()
+    {
+        $s = new Sanitizer;
+        $d = ['name' => 'Dayle'];
+        $s->sanitize([
+            'name' => [
+                function ($value) {
+                    return mb_strtolower($value);
+                },
+            ],
+        ], $d);
+        $this->assertEquals('dayle', $d['name']);
+    }
+
     public function testThatACallableRuleCanBeUsed()
     {
         $s = new Sanitizer;


### PR DESCRIPTION
For example,
```php
$rules = [
    'name' => [
	'trim',
	function ($value) {
	    return strtoupper($value);
	}
    ],
    'email' => 'trim|strtolower'
];
```