### PR TITLE
Support for wildcard (*) in the sanitization rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,9 +14,12 @@ Sanitizers can be used to standardize data to ease validation, or provide data c
 First construct a rules array.
 
     $rules = [
-        'name'      => 'trim',
-        'email'     => 'trim|strtolower'
+        'number_of_users' => 'trim|intval',
+        'users.*.name'      => 'trim',
+        'users.*.email'     => 'trim|strtolower',
+        'users.*.company_info.company_name' => 'trim|strtoupper'
     ];
+
 
 Rules can contain either callable functions, or the name of a sanitizer binding (more later). You can use either a pipe `|` or an array to specify multiple sanitization rules.
 
@@ -29,14 +32,32 @@ Here's a full example.
 
     // Construct rules array.
     $rules = [
-        'name'      => 'trim',
-        'email'     => 'trim|strtolower'
+        'number_of_users' => 'trim|intval',
+        'users.*.name'      => 'trim',
+        'users.*.email'     => 'trim|strtolower',
+        'users.*.company_info.company_name' => 'trim|strtoupper'
     ];
+
 
     // Data array to be sanitized.
     $data = [
-        'name' => ' Dayle ',
-        'email' => ' me@DAYLEREES.com'
+        'number_of_users' => 2.1,
+        'users' => [
+            [
+                'name' => ' Dayle ',
+                'email' => ' me@DAYLEREES.com',
+                'company_info' => [
+                    'company_name' => 'test company'
+                ]
+            ],
+            [
+                'name' => ' Tony ',
+                'email' => ' me@AveNgers.com',
+                'company_info' => [
+                    'company_name' => 's.h.i.e.l.d'
+                ]
+            ],
+        ]
     ];
 
     // Construct a new sanitizer.
@@ -46,12 +67,37 @@ Here's a full example.
     $sanitizer->sanitize($rules, $data);
 
 Here's the content of `$data` after execution.
+```
+[
+    [number_of_users] => 2
+    [users] => Array
+        (
+            [0] => Array
+                (
+                    [name] => Dayle
+                    [email] => me@daylerees.com
+                    [company_info] => Array
+                        (
+                            [company_name] => TEST COMPANY
+                        )
 
-    [
-        'name' => 'Dayle',
-        'email' => 'me@daylerees.com'
-    ]
+                )
 
+            [1] => Array
+                (
+                    [name] => Tony
+                    [email] => me@avengers.com
+                    [company_info] => Array
+                        (
+                            [company_name] => S.H.I.E.L.D
+                        )
+
+                )
+
+        )
+
+]
+```
 Using the Laravel facade, the syntax can be made a little cleaner.
 
     Sanitizer::sanitize($rules, $data);

--- a/src/ArrayDot.php
+++ b/src/ArrayDot.php
@@ -10,7 +10,7 @@ class ArrayDot
      * @param array $array Array to be checked
      * @return boolean
      */
-    public static function isMultiDimensionalArray(array $array): bool
+    public static function isMultiDimensionalArray($array)
     {
         rsort($array);
         return isset($array[0]) && is_array($array[0]);
@@ -23,7 +23,7 @@ class ArrayDot
      * @param  array  $array
      * @return array
      */
-    public static function collapse($array): array
+    public static function collapse($array)
     {
         if (!static::isMultiDimensionalArray($array)) {
             return $array;
@@ -48,7 +48,7 @@ class ArrayDot
      * @param string $prefix Prefix to be applied on found keys
      * @return array
      */
-    public static function resolveWildcardKey(array $array, $key = null, string $prefix = ''): array
+    public static function resolveWildcardKey($array, $key = null, $prefix = '')
     {
         $prefixSegments = [];
 

--- a/src/ArrayDot.php
+++ b/src/ArrayDot.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Rees\Sanitizer;
+
+class ArrayDot
+{
+    /**
+     * Checks whether the array is multidimensional or not
+     *
+     * @param array $array Array to be checked
+     * @return boolean
+     */
+    public static function isMultiDimensionalArray(array $array): bool
+    {
+        rsort($array);
+        return isset($array[0]) && is_array($array[0]);
+    }
+
+
+    /**
+     * Collapse an array of arrays into a single array.
+     * Adapted from: https://github.com/illuminate/support/blob/5.8/Arr.php#L47
+     * @param  array  $array
+     * @return array
+     */
+    public static function collapse($array): array
+    {
+        if(!static::isMultiDimensionalArray($array)){
+            return $array;
+        }
+
+        $results = [];
+        foreach ($array as $values) {
+            if (! is_array($values)) {
+                continue;
+            }
+            $results = array_merge($results, $values);
+        }
+
+        return $results;
+    }
+
+    /**
+     * Resolves wild card key to possible keys and returns array of those possible keys
+     *
+     * @param array $array Array in which keys to be found out
+     * @param string $key Wildcard Key passed in "dot" format
+     * @param string $prefix Prefix to be applied on found keys
+     * @return array
+     */
+    public static function resolveWildcardKey(array $array, $key = null, string $prefix = ''): array {
+        $prefixSegments = [];
+
+        // If no key is passed or * is the only string passed to the key, then 
+        // convert array to dot array & return keys from found in dot array
+        if (empty($key) || (is_string($key) && '*' == $key)) {
+            return array_map(
+                function($_key) use($prefix) {
+                    return !empty($prefix) ? $prefix . '.' . $_key : $_key;
+                },
+                array_keys(array_dot($array))
+            );
+        }
+
+        // If key ends with '.', do not allow to proceed.
+        if(is_string($key) && substr($key, -1) == '.'){
+            throw new \InvalidArgumentException('Key can not end with `.`');
+        }
+
+        // If key does not contain '*', then check if the passed key exists in the 
+        // array or not. If it exists, then return the key, else return blank []
+        if(is_string($key) && strpos($key, '*') === false){
+            $finalPrefix = !empty( $prefix ) ? $prefix . '.' . $key : $key;
+            return array_has($array, $finalPrefix) ? [$key] : [];
+        }
+
+        $key = is_array($key) ? $key : explode('.', $key);
+
+        while (! is_null($segment = array_shift($key))) {
+
+            if ($segment === '*') {
+                $result = [];
+               
+                foreach ($array as $internalKey => $item) {
+
+                    if(!is_array($item)) {
+                        $result[] = implode(
+                            '.', 
+                            array_filter(array_merge([$prefix], $prefixSegments, [$internalKey]), 'strlen')
+                        );
+                        continue;
+                    }
+
+                    $result[] = static::resolveWildcardKey(
+                        $item, 
+                        $key, 
+                        implode(
+                            '.', 
+                            array_filter(array_merge([$prefix],$prefixSegments, [$internalKey]), 'strlen')
+                        )
+                    );
+                }
+
+                return static::collapse($result);
+            }
+
+            // Invalid key is passed
+            if (is_array($array) && ! array_key_exists($segment, $array)) {
+                return [];
+            }
+
+            if (is_array($array) && array_key_exists($segment, $array)) {
+                $array = $array[$segment];
+                $prefixSegments[] = $segment;
+            }
+
+        }
+
+        $combinedPrefixSegments = implode('.', $prefixSegments);
+        return !empty($prefix) ? [$prefix . '.' . $combinedPrefixSegments] : [$combinedPrefixSegments];
+   
+    }
+
+}

--- a/src/ArrayDot.php
+++ b/src/ArrayDot.php
@@ -25,7 +25,7 @@ class ArrayDot
      */
     public static function collapse($array): array
     {
-        if(!static::isMultiDimensionalArray($array)){
+        if (!static::isMultiDimensionalArray($array)) {
             return $array;
         }
 
@@ -48,14 +48,15 @@ class ArrayDot
      * @param string $prefix Prefix to be applied on found keys
      * @return array
      */
-    public static function resolveWildcardKey(array $array, $key = null, string $prefix = ''): array {
+    public static function resolveWildcardKey(array $array, $key = null, string $prefix = ''): array
+    {
         $prefixSegments = [];
 
-        // If no key is passed or * is the only string passed to the key, then 
+        // If no key is passed or * is the only string passed to the key, then
         // convert array to dot array & return keys from found in dot array
         if (empty($key) || (is_string($key) && '*' == $key)) {
             return array_map(
-                function($_key) use($prefix) {
+                function ($_key) use ($prefix) {
                     return !empty($prefix) ? $prefix . '.' . $_key : $_key;
                 },
                 array_keys(array_dot($array))
@@ -63,40 +64,38 @@ class ArrayDot
         }
 
         // If key ends with '.', do not allow to proceed.
-        if(is_string($key) && substr($key, -1) == '.'){
+        if (is_string($key) && substr($key, -1) == '.') {
             throw new \InvalidArgumentException('Key can not end with `.`');
         }
 
-        // If key does not contain '*', then check if the passed key exists in the 
+        // If key does not contain '*', then check if the passed key exists in the
         // array or not. If it exists, then return the key, else return blank []
-        if(is_string($key) && strpos($key, '*') === false){
-            $finalPrefix = !empty( $prefix ) ? $prefix . '.' . $key : $key;
+        if (is_string($key) && strpos($key, '*') === false) {
+            $finalPrefix = !empty($prefix) ? $prefix . '.' . $key : $key;
             return array_has($array, $finalPrefix) ? [$key] : [];
         }
 
         $key = is_array($key) ? $key : explode('.', $key);
 
         while (! is_null($segment = array_shift($key))) {
-
             if ($segment === '*') {
                 $result = [];
                
                 foreach ($array as $internalKey => $item) {
-
-                    if(!is_array($item)) {
+                    if (!is_array($item)) {
                         $result[] = implode(
-                            '.', 
+                            '.',
                             array_filter(array_merge([$prefix], $prefixSegments, [$internalKey]), 'strlen')
                         );
                         continue;
                     }
 
                     $result[] = static::resolveWildcardKey(
-                        $item, 
-                        $key, 
+                        $item,
+                        $key,
                         implode(
-                            '.', 
-                            array_filter(array_merge([$prefix],$prefixSegments, [$internalKey]), 'strlen')
+                            '.',
+                            array_filter(array_merge([$prefix], $prefixSegments, [$internalKey]), 'strlen')
                         )
                     );
                 }
@@ -113,12 +112,9 @@ class ArrayDot
                 $array = $array[$segment];
                 $prefixSegments[] = $segment;
             }
-
         }
 
         $combinedPrefixSegments = implode('.', $prefixSegments);
         return !empty($prefix) ? [$prefix . '.' . $combinedPrefixSegments] : [$combinedPrefixSegments];
-   
     }
-
 }

--- a/src/Sanitizer.php
+++ b/src/Sanitizer.php
@@ -65,7 +65,7 @@ class Sanitizer
         $this->runGlobalSanitizers($rules, $data);
 
         // Rules which contain wildcards need to be resolved to find out actual keys 
-        $this->resolveWildcardRules($rules, $data);
+        $rules = $this->resolveWildcardRules($rules, $data);
 
         // Iterate rules to be applied.
         foreach ($rules as $field => $ruleset) {
@@ -118,11 +118,18 @@ class Sanitizer
         }
     }
 
-    protected function resolveWildcardRules(&$rules, $data)
+    /**
+     * Expand/Resolve wildcard rules to individual rules
+     *
+     * @param array $rules
+     * @param array $data
+     * @return array
+     */
+    public function resolveWildcardRules($rules, $data)
     {
         $resolvedRules = [];
 
-        foreach( $rules as $field => $ruleset ){
+        foreach ($rules as $field => $ruleset){
 
             // If it is a wildcard rule
             if( strpos($field, '.*') !== false ){
@@ -133,7 +140,7 @@ class Sanitizer
         }
 
         $resolvedRules = array_collapse($resolvedRules);
-        $rules = array_merge($resolvedRules, $rules);
+        return array_merge($resolvedRules, $rules); 
     }
 
     /**

--- a/tests/ArrayDotTest.php
+++ b/tests/ArrayDotTest.php
@@ -60,7 +60,7 @@ class ArrayDotTest extends PHPUnit_Framework_TestCase
                 ]
             ]
         ];
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->setExpectedException('InvalidArgumentException', 'Key can not end with `.`');
         ArrayDot::resolveWildcardKey($array, 'a.id.');
     }
 

--- a/tests/ArrayDotTest.php
+++ b/tests/ArrayDotTest.php
@@ -1,0 +1,136 @@
+<?php
+use Rees\Sanitizer\ArrayDot;
+
+class ArrayDotTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testThatIsMultiDimensionalArrayMethodCanCheckIfArrayIsMultiDimensional(){
+        $array = [
+            'foo' => [
+                'bar' => [
+                    'baz' => 123,
+                    'qux' => 456
+                ]
+            ],
+            'comments' => [
+                ['id' => 1, 'text' => 'foo'],
+                ['id' => 2, 'text' => 'bar'],
+                ['id' => 3, 'text' => 'baz'],
+            ]
+        ];
+
+        $this->assertTrue(ArrayDot::isMultiDimensionalArray($array));
+
+        $array =[
+            'foo',
+            'bar',
+            'baz'
+        ];
+
+        $this->assertFalse(ArrayDot::isMultiDimensionalArray($array));
+    }
+
+    public function testThatCollapseMethodCanConvertCollectionOfArraysToSingleFlatArray(){
+        $array = [
+            [1, 2, 3], 
+            [4, 5, 6], 
+            [7, 8, 9]
+        ];
+
+        $this->assertEquals(ArrayDot::collapse($array), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    public function testThatResolveWildCardKeyThrowsExceptionIfKeyEndsWithDot(){
+        $array = [
+            'users' => [
+                'subscribers' => [
+                    'sumit' => [
+                        'id' => '12345',
+                        'name' => 'Sumit'
+                    ],
+                    'tony' => [
+                        'id' => '780643'
+                    ],
+                    'steve' => [
+                        'id' => '532678'
+                    ]
+                ]
+            ]
+        ];
+        $this->setExpectedException(InvalidArgumentException::class);
+        ArrayDot::resolveWildcardKey($array, 'a.id.');
+    }
+
+    public function testThatResolveWildCardKeyCanFindAllPossibleKeys(){
+        
+        $array = [
+            'users' => [
+                'subscribers' => [
+                    'sumit' => [
+                        'id' => '12345',
+                        'name' => 'Sumit'
+                    ],
+                    'tony' => [
+                        'id' => '780643',
+                    ],
+                    'steve' => [
+                        'id' => '532678'
+                    ]
+                ]
+            ]
+        ];
+
+        //Passing no key returns array of all dot keys
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array), [
+            'users.subscribers.sumit.id',
+            'users.subscribers.sumit.name',
+            'users.subscribers.tony.id',
+            'users.subscribers.steve.id'
+        ]);
+
+        // Passing no key is similar to passing only *
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array), ArrayDot::resolveWildcardKey($array, '*'));
+
+        // Passing a non-wildcard key will return the key as it is if it is a valid key
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.subscribers'), [
+            'users.subscribers'
+        ]);
+
+        // Passing invalid keys returns blank array
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.b.c'), []);
+
+        // Each star represents one level of hierarchy. `id` key is present at 3rd level hierarchy
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.*.id'), []);
+
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.*.*.id'), [
+            'users.subscribers.sumit.id',
+            'users.subscribers.tony.id',
+            'users.subscribers.steve.id'
+        ]);
+
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.subscribers.*'), [
+            'users.subscribers.sumit.id',
+            'users.subscribers.sumit.name',
+            'users.subscribers.tony.id',
+            'users.subscribers.steve.id'
+        ]);
+
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.subscribers.*.id'), [
+            'users.subscribers.sumit.id',
+            'users.subscribers.tony.id',
+            'users.subscribers.steve.id'
+        ]);
+
+
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, 'users.*.sumit.*'), [
+            'users.subscribers.sumit.id',
+            'users.subscribers.sumit.name'
+        ]);
+
+        $this->assertEquals(ArrayDot::resolveWildcardKey($array, '*.*.sumit'), [
+            'users.subscribers.sumit',
+        ]);
+
+    }
+
+}

--- a/tests/ArrayDotTest.php
+++ b/tests/ArrayDotTest.php
@@ -4,7 +4,8 @@ use Rees\Sanitizer\ArrayDot;
 class ArrayDotTest extends PHPUnit_Framework_TestCase
 {
 
-    public function testThatIsMultiDimensionalArrayMethodCanCheckIfArrayIsMultiDimensional(){
+    public function testThatIsMultiDimensionalArrayMethodCanCheckIfArrayIsMultiDimensional()
+    {
         $array = [
             'foo' => [
                 'bar' => [
@@ -30,17 +31,19 @@ class ArrayDotTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(ArrayDot::isMultiDimensionalArray($array));
     }
 
-    public function testThatCollapseMethodCanConvertCollectionOfArraysToSingleFlatArray(){
+    public function testThatCollapseMethodCanConvertCollectionOfArraysToSingleFlatArray()
+    {
         $array = [
-            [1, 2, 3], 
-            [4, 5, 6], 
+            [1, 2, 3],
+            [4, 5, 6],
             [7, 8, 9]
         ];
 
         $this->assertEquals(ArrayDot::collapse($array), [1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 
-    public function testThatResolveWildCardKeyThrowsExceptionIfKeyEndsWithDot(){
+    public function testThatResolveWildCardKeyThrowsExceptionIfKeyEndsWithDot()
+    {
         $array = [
             'users' => [
                 'subscribers' => [
@@ -61,7 +64,8 @@ class ArrayDotTest extends PHPUnit_Framework_TestCase
         ArrayDot::resolveWildcardKey($array, 'a.id.');
     }
 
-    public function testThatResolveWildCardKeyCanFindAllPossibleKeys(){
+    public function testThatResolveWildCardKeyCanFindAllPossibleKeys()
+    {
         
         $array = [
             'users' => [
@@ -130,7 +134,5 @@ class ArrayDotTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(ArrayDot::resolveWildcardKey($array, '*.*.sumit'), [
             'users.subscribers.sumit',
         ]);
-
     }
-
 }

--- a/tests/SanitizerTest.php
+++ b/tests/SanitizerTest.php
@@ -9,6 +9,50 @@ class SanitizerTest extends PHPUnit_Framework_TestCase
         $s = new Sanitizer;
     }
 
+    public function testThatSanitizerCanSanitizeWildcardRules()
+    {
+        $s = new Sanitizer;
+        $s->register('reverse', function($field) { return strrev($field); });
+
+        $d = [
+            'users' =>[
+                [
+                    'id' => 123,
+                    'name' => 'Sumit',
+                ],
+                [
+                    'id' => 456,
+                    'name' => 'David',
+                    'company' => 'abc'
+                ]
+            ]
+        ];
+
+        $s->sanitize([
+            'users.*.name' => 'reverse',
+            'users.*.id' => 'reverse',
+            '*.*.company' => 'strtoupper'
+        ], $d);
+        
+
+        $this->assertEquals(
+            $d, 
+            [
+                'users' =>[
+                    [
+                        'id' => 321,
+                        'name' => 'timuS',
+                    ],
+                    [
+                        'id' => 654,
+                        'name' => 'divaD',
+                        'company' => 'ABC'
+                    ]
+                ]
+            ]
+        );
+    }
+
     public function testThatSanitizerCanSanitizeWithClosure()
     {
         $s = new Sanitizer;


### PR DESCRIPTION
This pull request aims to add a support for wildcards in the sanitization rules.

Adding a support for wildcards helps in performing sanitization on dynamic fields. Each star corresponds to one level of hierarchy.

Example of how it works:
```php
$s = new Sanitizer;
$s->register('reverse', function($field) { return strrev($field); });

$d = [
    'users' =>[
        [
            'id' => 123,
            'name' => 'Sumit',
        ],
        [
            'id' => 456,
            'name' => 'David',
            'company' => 'abc'
        ]
    ]
];

$s->sanitize([
    'users.*.name' => 'reverse',
    'users.*.id' => 'reverse',
    '*.*.company' => 'strtoupper'
], $d);
```

The final data after sanitization will look like this
```php
[
    'users' =>[
        [
            'id' => 321,
            'name' => 'timuS',
        ],
        [
            'id' => 654,
            'name' => 'divaD',
            'company' => 'ABC'
        ]
    ]
]
```